### PR TITLE
Changes for adding Power VS platform for ingress controller

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -171,6 +171,24 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 			expect: true,
 		},
 		{
+			description:  "external load balancer for Power VS platform",
+			platform:     PowerVSPlatformType,
+			strategyType: operatorv1.LoadBalancerServiceStrategyType,
+			lbStrategy: operatorv1.LoadBalancerStrategy{
+				Scope: operatorv1.ExternalLoadBalancer,
+			},
+			expect: true,
+		},
+		{
+			description:  "internal load balancer for Power VS platform",
+			platform:     PowerVSPlatformType,
+			strategyType: operatorv1.LoadBalancerServiceStrategyType,
+			lbStrategy: operatorv1.LoadBalancerStrategy{
+				Scope: operatorv1.InternalLoadBalancer,
+			},
+			expect: true,
+		},
+		{
 			description:  "external load balancer for azure platform",
 			platform:     configv1.AzurePlatformType,
 			strategyType: operatorv1.LoadBalancerServiceStrategyType,
@@ -364,6 +382,25 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 				}
 			}
 		case configv1.IBMCloudPlatformType:
+			if isInternal {
+				if err := checkServiceHasAnnotation(svc, iksLBScopeAnnotation, true, iksLBScopePrivate); err != nil {
+					t.Errorf("annotation check for test %q failed: %v", tc.description, err)
+				}
+				// The ibm public annotation value should not exist for an internal LB.
+				if err := checkServiceHasAnnotation(svc, iksLBScopeAnnotation, true, iksLBScopePublic); err == nil {
+					t.Errorf("annotation check for test %q failed; unexpected annotation %s: %s", tc.description, iksLBScopeAnnotation, iksLBScopePublic)
+				}
+			} else {
+				if err := checkServiceHasAnnotation(svc, iksLBScopeAnnotation, true, iksLBScopePublic); err != nil {
+					t.Errorf("annotation check for test %q failed: %v", tc.description, err)
+				}
+				// The ibm private annotation value should not exist for an external LB.
+				if err := checkServiceHasAnnotation(svc, iksLBScopeAnnotation, true, iksLBScopePrivate); err == nil {
+					t.Errorf("annotation check for test %q failed; unexpected annotation %s: %s", tc.description, iksLBScopeAnnotation, iksLBScopePrivate)
+				}
+			}
+		case PowerVSPlatformType:
+			//Power VS platform uses same Load Balancer service as like IBM Cloud platform
 			if isInternal {
 				if err := checkServiceHasAnnotation(svc, iksLBScopeAnnotation, true, iksLBScopePrivate); err != nil {
 					t.Errorf("annotation check for test %q failed: %v", tc.description, err)


### PR DESCRIPTION
Following steps are done to validate the changes
1. Locally stared the IBM Cloud provider by pointing ocp cluster kubeconfig
2. Locally started the ingress-operator


1. Created a new ingress controller with following spec
```

apiVersion: operator.openshift.io/v1
kind: IngressController
metadata:
  name: karthik
  namespace: openshift-ingress-operator
spec:
  domain: scnl-ibm.com
  endpointPublishingStrategy:
    type: LoadBalancerService
    loadBalancer:
      scope: External
```

2. Created a deployment with following spec

```
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: go-web-app
spec:
  replicas: 2
  selector:
    matchLabels:
      name: go-web-app
  template:
    metadata:
      labels:
        name: go-web-app
    spec:
      containers:
        - name: application
          image: karthikkn27/go-web-app-on-scratch
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 7777
```

3. Created a service
```
---
apiVersion: v1
kind: Service
metadata:
  name: ggg
  labels:
    app: router
    ingresscontroller.operator.openshift.io/owning-ingresscontroller: default
    router: router-default
  annotations:
      service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: public
spec:
  type: NodePort
  ports:
  - name: http
    port: 80
    targetPort: 7777
  selector:
    name: go-web-app
  externalTrafficPolicy: Cluster
```

4. Exposed the service
`oc expose ggg`

5. Final output
```
karthikkn@Karthiks-MacBook-Pro goWebApp % oc get routes -A -o wide        
NAMESPACE                  NAME                HOST/PORT                                                                          PATH   SERVICES            PORT    TERMINATION            WILDCARD
default                    ggg                 ggg-default.apps.rdr-karthik1.scnl-ibm.com ... 1 more                                     ggg                 http                           None
```
6. Manually added the DNS to LB mappin in IBM Cloud CIS and after that able to access the service from browser `ggg-default.apps.rdr-karthik1.scnl-ibm.com`